### PR TITLE
feat(aspire): Fail fast on Docker unhealthy + configurable startup timeout + HTTP-only mode

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,13 @@
     <Authors>Ryan Burnham</Authors>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/rburnham52/fluent-ui-scaffold</RepositoryUrl>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <!--
+      No default TargetFrameworks here. Every csproj in the repo sets its own
+      TargetFramework or TargetFrameworks explicitly. A multi-value plural here
+      would bleed into singular-target projects (notably samples/SampleApp) and
+      cause "dotnet run" (used by Aspire DCP to launch project resources) to
+      see multiple TFMs and refuse to start without an explicit framework flag.
+    -->
     <LangVersion>latest</LangVersion>
     <!-- Version Management -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/FluentUIScaffold.AspireHosting/AspireHostingExtensions.cs
+++ b/src/FluentUIScaffold.AspireHosting/AspireHostingExtensions.cs
@@ -19,6 +19,7 @@ namespace FluentUIScaffold.AspireHosting
     internal sealed class AspireHostingConfiguration
     {
         public bool SkipDockerPreflightCheck { get; set; }
+        public TimeSpan? AspireStartupTimeout { get; set; }
     }
 
     /// <summary>
@@ -65,10 +66,15 @@ namespace FluentUIScaffold.AspireHosting
                 services.AddSingleton<AspireHostingStrategy<TEntryPoint>>(sp =>
                 {
                     var scaffoldOptions = sp.GetRequiredService<FluentUIScaffoldOptions>();
-                    return new AspireHostingStrategy<TEntryPoint>(configure, scaffoldOptions, baseUrlResourceName)
+                    var strategy = new AspireHostingStrategy<TEntryPoint>(configure, scaffoldOptions, baseUrlResourceName)
                     {
                         SkipDockerPreflightCheck = aspireConfig.SkipDockerPreflightCheck,
                     };
+                    if (aspireConfig.AspireStartupTimeout.HasValue)
+                    {
+                        strategy.AspireStartupTimeout = aspireConfig.AspireStartupTimeout.Value;
+                    }
+                    return strategy;
                 });
                 services.AddSingleton<IHostingStrategy>(sp =>
                     sp.GetRequiredService<AspireHostingStrategy<TEntryPoint>>());
@@ -122,6 +128,26 @@ namespace FluentUIScaffold.AspireHosting
         public static FluentUIScaffoldBuilder SkipDockerPreflightCheck(this FluentUIScaffoldBuilder builder)
         {
             GetOrCreateConfig(builder).SkipDockerPreflightCheck = true;
+            return builder;
+        }
+
+        /// <summary>
+        /// Bounds the time spent waiting for the Aspire AppHost to finish startup.
+        /// When the timeout fires, a <see cref="TimeoutException"/> is thrown instead
+        /// of hanging indefinitely. Default is 90 seconds.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// During the wait, FluentUIScaffold emits an <c>ILogger.LogInformation</c> heartbeat
+        /// line every 10 seconds (<c>"Aspire host starting... ({elapsed}s elapsed)"</c>) so
+        /// you can tell whether startup is making progress.
+        /// </para>
+        /// </remarks>
+        public static FluentUIScaffoldBuilder WithAspireStartupTimeout(this FluentUIScaffoldBuilder builder, TimeSpan timeout)
+        {
+            if (timeout <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(timeout), "Startup timeout must be positive.");
+            GetOrCreateConfig(builder).AspireStartupTimeout = timeout;
             return builder;
         }
 

--- a/src/FluentUIScaffold.AspireHosting/AspireHostingExtensions.cs
+++ b/src/FluentUIScaffold.AspireHosting/AspireHostingExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Aspire.Hosting;
 using Aspire.Hosting.Testing;
@@ -20,6 +21,7 @@ namespace FluentUIScaffold.AspireHosting
     {
         public bool SkipDockerPreflightCheck { get; set; }
         public TimeSpan? AspireStartupTimeout { get; set; }
+        public bool HttpOnlyMode { get; set; }
     }
 
     /// <summary>
@@ -149,6 +151,65 @@ namespace FluentUIScaffold.AspireHosting
                 throw new ArgumentOutOfRangeException(nameof(timeout), "Startup timeout must be positive.");
             GetOrCreateConfig(builder).AspireStartupTimeout = timeout;
             return builder;
+        }
+
+        /// <summary>
+        /// Forces all ASP.NET Core resources hosted by Aspire to bind HTTP only and disables
+        /// <c>UseHttpsRedirection</c>'s port resolution. Opt-in; disabled by default.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The footgun this avoids:</b> many ASP.NET Core templates ship with
+        /// <c>app.UseHttpsRedirection()</c> enabled, which is fine in Development but in
+        /// other environments (including <c>Testing</c>) issues a <c>307 Temporary Redirect</c>
+        /// to the absolute HTTPS upstream URL, e.g. <c>https://localhost:7039/api/...</c>.
+        /// When the API sits behind a YARP reverse proxy serving an SPA, the browser sees
+        /// the absolute redirect and the SPA's CSP <c>connect-src 'self'</c> blocks the
+        /// follow-up request, producing a cryptic <c>"Failed to fetch"</c> in every test.
+        /// </para>
+        /// <para>
+        /// Enabling HTTP-only mode injects:
+        /// <list type="bullet">
+        ///   <item><c>ASPNETCORE_URLS=http://+:0</c> — Aspire picks the port; no HTTPS endpoint is advertised.</item>
+        ///   <item><c>ASPNETCORE_HTTPS_PORT=</c> (empty) — disables the <c>UseHttpsRedirection</c> middleware's port resolution.</item>
+        /// </list>
+        /// These env vars are propagated to every Aspire-hosted process via FluentUIScaffold's
+        /// existing environment-variable bag.
+        /// </para>
+        /// <para>
+        /// Off by default because it changes wire-protocol expectations — opt in only when
+        /// your tests genuinely run over HTTP.
+        /// </para>
+        /// </remarks>
+        /// <param name="builder">The FluentUIScaffold builder.</param>
+        /// <param name="enabled">When true (default), enables HTTP-only mode.</param>
+        public static FluentUIScaffoldBuilder WithHttpOnlyMode(this FluentUIScaffoldBuilder builder, bool enabled = true)
+        {
+            GetOrCreateConfig(builder).HttpOnlyMode = enabled;
+            if (enabled)
+            {
+                ApplyHttpOnlyModeEnvVars(builder);
+            }
+            return builder;
+        }
+
+        /// <summary>
+        /// Names of the env vars HTTP-only mode sets. Exposed for tests.
+        /// </summary>
+        internal static readonly IReadOnlyDictionary<string, string> HttpOnlyEnvVars
+            = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ASPNETCORE_URLS"] = "http://+:0",
+                ["ASPNETCORE_HTTPS_PORT"] = string.Empty,
+            };
+
+        private static void ApplyHttpOnlyModeEnvVars(FluentUIScaffoldBuilder builder)
+        {
+            // Use WithEnvironmentVariable so the same key-validation + storage path is exercised.
+            foreach (var kv in HttpOnlyEnvVars)
+            {
+                builder.WithEnvironmentVariable(kv.Key, kv.Value);
+            }
         }
 
         /// <summary>

--- a/src/FluentUIScaffold.AspireHosting/AspireHostingExtensions.cs
+++ b/src/FluentUIScaffold.AspireHosting/AspireHostingExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Aspire.Hosting;
 using Aspire.Hosting.Testing;
 
@@ -11,10 +13,29 @@ using Microsoft.Extensions.Logging;
 namespace FluentUIScaffold.AspireHosting
 {
     /// <summary>
+    /// Configuration bag for Aspire-specific options that the builder extensions need to
+    /// propagate to the strategy at DI-resolution time.
+    /// </summary>
+    internal sealed class AspireHostingConfiguration
+    {
+        public bool SkipDockerPreflightCheck { get; set; }
+    }
+
+    /// <summary>
     /// Extension methods for configuring Aspire hosting with FluentUIScaffold.
     /// </summary>
     public static class AspireHostingExtensions
     {
+        // Per-builder configuration store. ConditionalWeakTable lets us attach Aspire-specific
+        // settings to the builder without modifying Core's public API surface.
+        private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<FluentUIScaffoldBuilder, AspireHostingConfiguration> _configs
+            = new();
+
+        internal static AspireHostingConfiguration GetOrCreateConfig(FluentUIScaffoldBuilder builder)
+        {
+            return _configs.GetValue(builder, _ => new AspireHostingConfiguration());
+        }
+
         /// <summary>
         /// Configures hosting via Aspire's DistributedApplicationTestingBuilder.
         /// Delegates all lifecycle management to Aspire's testing infrastructure.
@@ -36,13 +57,18 @@ namespace FluentUIScaffold.AspireHosting
             // Enforce single-strategy guard (same as DotNet/Node paths)
             builder.SetHostingStrategyRegistered();
 
+            var aspireConfig = GetOrCreateConfig(builder);
+
             // Register the hosting strategy via factory delegate so it receives the final options
             builder.ConfigureServices(services =>
             {
                 services.AddSingleton<AspireHostingStrategy<TEntryPoint>>(sp =>
                 {
                     var scaffoldOptions = sp.GetRequiredService<FluentUIScaffoldOptions>();
-                    return new AspireHostingStrategy<TEntryPoint>(configure, scaffoldOptions, baseUrlResourceName);
+                    return new AspireHostingStrategy<TEntryPoint>(configure, scaffoldOptions, baseUrlResourceName)
+                    {
+                        SkipDockerPreflightCheck = aspireConfig.SkipDockerPreflightCheck,
+                    };
                 });
                 services.AddSingleton<IHostingStrategy>(sp =>
                     sp.GetRequiredService<AspireHostingStrategy<TEntryPoint>>());
@@ -72,6 +98,30 @@ namespace FluentUIScaffold.AspireHosting
                 options.BaseUrl = ApplyBaseUrlPrefix(result.BaseUrl, baseUrlPrefix);
             });
 
+            return builder;
+        }
+
+        /// <summary>
+        /// Opts out of the Docker daemon pre-flight check that <c>UseAspireHosting</c>
+        /// performs by default.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// By default, <c>UseAspireHosting</c> runs <c>docker info</c> with a 2-second
+        /// timeout before booting the Aspire AppHost. If the daemon is unreachable it
+        /// throws a single-line <see cref="InvalidOperationException"/> instead of letting
+        /// Aspire hang and bury the failure ~20 stack frames deep behind
+        /// <c>DistributedApplicationFactory → DcpHost → DcpDependencyCheck</c>.
+        /// </para>
+        /// <para>
+        /// Call this when you run against a remote container runtime where the local
+        /// <c>docker</c> CLI is not installed but Aspire still works (e.g., DOCKER_HOST
+        /// points at a remote daemon).
+        /// </para>
+        /// </remarks>
+        public static FluentUIScaffoldBuilder SkipDockerPreflightCheck(this FluentUIScaffoldBuilder builder)
+        {
+            GetOrCreateConfig(builder).SkipDockerPreflightCheck = true;
             return builder;
         }
 

--- a/src/FluentUIScaffold.AspireHosting/AspireHostingStrategy.cs
+++ b/src/FluentUIScaffold.AspireHosting/AspireHostingStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -51,6 +52,19 @@ namespace FluentUIScaffold.AspireHosting
         /// <c>docker info</c> probe would (incorrectly) fail.
         /// </summary>
         public bool SkipDockerPreflightCheck { get; set; }
+
+        /// <summary>
+        /// Maximum time to wait for the Aspire AppHost to finish StartAsync.
+        /// When exceeded, a <see cref="TimeoutException"/> is thrown instead of hanging indefinitely.
+        /// Default 90 seconds.
+        /// </summary>
+        public TimeSpan AspireStartupTimeout { get; set; } = TimeSpan.FromSeconds(90);
+
+        /// <summary>
+        /// Interval between "still starting..." heartbeat log lines emitted during Aspire startup.
+        /// Default 10 seconds.
+        /// </summary>
+        public TimeSpan StartupHeartbeatInterval { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// Creates a new AspireHostingStrategy for the specified AppHost entry point.
@@ -121,7 +135,7 @@ namespace FluentUIScaffold.AspireHosting
                 _app = await appBuilder.BuildAsync(cancellationToken);
 
                 logger.LogInformation("Starting distributed application");
-                await _app.StartAsync(cancellationToken);
+                await StartAppWithTimeoutAndHeartbeatAsync(_app, logger, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -257,6 +271,92 @@ namespace FluentUIScaffold.AspireHosting
             }
 
             _envVarSnapshot = null;
+        }
+
+        /// <summary>
+        /// Wraps <see cref="DistributedApplication.StartAsync"/> with a bounded timeout
+        /// and periodic heartbeat log lines so the caller can see whether startup is
+        /// progressing or stuck. On timeout, throws <see cref="TimeoutException"/> with
+        /// an informative message naming the timeout duration.
+        /// </summary>
+        private Task StartAppWithTimeoutAndHeartbeatAsync(
+            DistributedApplication app,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            return StartWithTimeoutAndHeartbeatAsync(
+                ct => app.StartAsync(ct),
+                AspireStartupTimeout,
+                StartupHeartbeatInterval,
+                logger,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Test-visible core of the timeout + heartbeat logic. Runs <paramref name="startupFactory"/>,
+        /// emits a "still starting..." log line every <paramref name="heartbeatInterval"/>, and throws
+        /// <see cref="TimeoutException"/> if the task does not complete within <paramref name="timeout"/>.
+        /// </summary>
+        internal static async Task StartWithTimeoutAndHeartbeatAsync(
+            Func<CancellationToken, Task> startupFactory,
+            TimeSpan timeout,
+            TimeSpan heartbeatInterval,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            using var startupCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            var sw = Stopwatch.StartNew();
+            var heartbeatTask = RunHeartbeatAsync(sw, heartbeatInterval, logger, heartbeatCts.Token);
+
+            var startupTask = startupFactory(startupCts.Token);
+            var timeoutTask = Task.Delay(timeout, cancellationToken);
+
+            var winner = await Task.WhenAny(startupTask, timeoutTask).ConfigureAwait(false);
+
+            heartbeatCts.Cancel();
+            try { await heartbeatTask.ConfigureAwait(false); } catch { /* heartbeat is best-effort */ }
+
+            if (winner == startupTask)
+            {
+                // Surface startup exceptions normally
+                await startupTask.ConfigureAwait(false);
+                return;
+            }
+
+            // Timeout fired first — try to cancel the in-flight startup so it doesn't
+            // continue churning in the background.
+            try { startupCts.Cancel(); } catch { /* best-effort */ }
+
+            throw new TimeoutException(
+                $"Aspire AppHost did not start within {timeout.TotalSeconds:F0}s. " +
+                "Increase the timeout via .WithAspireStartupTimeout(TimeSpan) if your AppHost legitimately needs longer, " +
+                "or check Docker / container logs for a stuck resource.");
+        }
+
+        private static async Task RunHeartbeatAsync(
+            Stopwatch sw,
+            TimeSpan interval,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            if (interval <= TimeSpan.Zero) return;
+
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+                    logger.LogInformation(
+                        "Aspire host starting... ({Elapsed}s elapsed)",
+                        (int)sw.Elapsed.TotalSeconds);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // expected on completion
+            }
         }
 
         private async Task VerifyHealthAsync(ILogger logger, CancellationToken cancellationToken)

--- a/src/FluentUIScaffold.AspireHosting/AspireHostingStrategy.cs
+++ b/src/FluentUIScaffold.AspireHosting/AspireHostingStrategy.cs
@@ -46,6 +46,13 @@ namespace FluentUIScaffold.AspireHosting
         private bool _isStarted;
 
         /// <summary>
+        /// When true, the Docker daemon pre-flight check is skipped. Default false.
+        /// Useful for users running against remote container runtimes where a local
+        /// <c>docker info</c> probe would (incorrectly) fail.
+        /// </summary>
+        public bool SkipDockerPreflightCheck { get; set; }
+
+        /// <summary>
         /// Creates a new AspireHostingStrategy for the specified AppHost entry point.
         /// </summary>
         /// <param name="configureAction">Action to configure the distributed application builder.</param>
@@ -81,6 +88,16 @@ namespace FluentUIScaffold.AspireHosting
             if (_isStarted) return new HostingResult(_baseUrl!, WasReused: true);
 
             logger.LogInformation("Starting Aspire host via AspireHostingStrategy<{EntryPoint}>", typeof(TEntryPoint).Name);
+
+            // Fail fast if Docker is unreachable, before Aspire gets a chance to hang.
+            // Aspire's own daemon health check is buried ~20 stack frames deep behind
+            // DistributedApplicationFactory → DcpHost → DcpDependencyCheck, so the real
+            // cause is invisible without --logger "console;verbosity=detailed".
+            if (!SkipDockerPreflightCheck)
+            {
+                await DockerPreflightCheck.EnsureDockerHealthyAsync(cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            }
 
             // Serialize env var mutations across all AspireHostingStrategy<T> instances.
             // Environment.SetEnvironmentVariable is process-global and not thread-safe

--- a/src/FluentUIScaffold.AspireHosting/DockerPreflightCheck.cs
+++ b/src/FluentUIScaffold.AspireHosting/DockerPreflightCheck.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FluentUIScaffold.AspireHosting
+{
+    /// <summary>
+    /// Performs a fast (≤2s) Docker daemon health check before Aspire bootstrap.
+    /// Surfaces a clear, single-line user-facing error when the daemon is unreachable
+    /// instead of letting Aspire hang and bury the failure ~20 stack frames deep.
+    /// </summary>
+    public static class DockerPreflightCheck
+    {
+        /// <summary>
+        /// The user-facing error message thrown when the Docker daemon is not reachable.
+        /// Exposed as a public constant so downstream tests can assert on the exact text.
+        /// </summary>
+        public const string DockerUnreachableMessage =
+            "Docker daemon is not reachable. FluentUIScaffold.AspireHosting requires Docker " +
+            "(or a compatible container runtime like Rancher Desktop, Podman with Docker compatibility) " +
+            "to be running." +
+            "\n\n" +
+            "Common causes:\n" +
+            "- Docker Desktop / Rancher Desktop is not started\n" +
+            "- Docker Desktop is in Resource Saver mode (click the tray icon to wake it)\n" +
+            "- The Docker daemon crashed (check the logs)" +
+            "\n\n" +
+            "Start your container runtime and try again.";
+
+        /// <summary>
+        /// Default timeout for the Docker health probe. Kept tight so a stuck daemon
+        /// fails fast instead of compounding into Aspire's longer startup hang.
+        /// </summary>
+        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(2);
+
+        /// <summary>
+        /// Runs <c>docker info --format "{{.ServerVersion}}"</c> with a short timeout.
+        /// Throws <see cref="InvalidOperationException"/> with <see cref="DockerUnreachableMessage"/>
+        /// and no inner exception (to keep the error single-line and not bury the cause)
+        /// if the command fails, times out, or returns no server version.
+        /// </summary>
+        /// <param name="timeout">Optional override for the probe timeout. Defaults to <see cref="DefaultTimeout"/>.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        public static async Task EnsureDockerHealthyAsync(
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default)
+        {
+            var effectiveTimeout = timeout ?? DefaultTimeout;
+
+            if (!await IsDockerHealthyAsync(effectiveTimeout, cancellationToken).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException(DockerUnreachableMessage);
+            }
+        }
+
+        /// <summary>
+        /// Probes the Docker daemon. Returns true if <c>docker info</c> exits with code 0
+        /// and produces non-empty output within the timeout. Returns false otherwise
+        /// (including when the docker binary is not on PATH at all).
+        /// </summary>
+        internal static async Task<bool> IsDockerHealthyAsync(
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            Process? process = null;
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "docker",
+                    Arguments = "info --format \"{{.ServerVersion}}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+
+                process = new Process { StartInfo = psi };
+
+                try
+                {
+                    if (!process.Start())
+                    {
+                        return false;
+                    }
+                }
+                catch
+                {
+                    // docker binary is not on PATH, or some other launch failure.
+                    return false;
+                }
+
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(timeout);
+
+                try
+                {
+#if NET8_0_OR_GREATER
+                    await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+#else
+                    var exited = process.WaitForExit((int)timeout.TotalMilliseconds);
+                    if (!exited)
+                    {
+                        TryKill(process);
+                        return false;
+                    }
+                    await Task.CompletedTask.ConfigureAwait(false);
+#endif
+                }
+                catch (OperationCanceledException)
+                {
+                    TryKill(process);
+                    return false;
+                }
+
+                if (process.ExitCode != 0)
+                {
+                    return false;
+                }
+
+                var stdout = await process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+                return !string.IsNullOrWhiteSpace(stdout);
+            }
+            catch
+            {
+                return false;
+            }
+            finally
+            {
+                process?.Dispose();
+            }
+        }
+
+        private static void TryKill(Process process)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch
+            {
+                // best-effort
+            }
+        }
+    }
+}

--- a/src/FluentUIScaffold.AspireHosting/README.md
+++ b/src/FluentUIScaffold.AspireHosting/README.md
@@ -22,6 +22,88 @@ var app = new FluentUIScaffoldBuilder()
     .Build<WebApp>();
 ```
 
+## Common gotchas
+
+### Docker daemon must be running
+
+`UseAspireHosting<TAppHost>()` requires Docker (or a compatible runtime such as
+Rancher Desktop or Podman with Docker compatibility). Before booting the Aspire
+AppHost, FluentUIScaffold runs a 2-second `docker info` probe and throws a
+clear, single-line `InvalidOperationException` if the daemon is unreachable —
+instead of letting Aspire hang and bury the real cause ~20 stack frames deep
+behind `DistributedApplicationFactory → DcpHost → DcpDependencyCheck`.
+
+Common reasons the probe fails:
+
+- Docker Desktop / Rancher Desktop is not started.
+- Docker Desktop is in **Resource Saver mode** — click the tray icon to wake
+  it. (After a host crash, Docker Desktop can land in Resource Saver and stay
+  there silently, which previously turned every `dotnet test` invocation into
+  an indefinite hang.)
+- The Docker daemon crashed.
+
+If you genuinely want to bypass the local probe — for example because Aspire
+is talking to a remote daemon via `DOCKER_HOST` — opt out with
+`.SkipDockerPreflightCheck()`:
+
+```csharp
+var app = new FluentUIScaffoldBuilder()
+    .UsePlaywright()
+    .UseAspireHosting<Projects.MyApp_AppHost>(appHost => { }, "web")
+    .SkipDockerPreflightCheck()
+    .Web<WebApp>(options => { })
+    .Build<WebApp>();
+```
+
+### HTTPS redirect + YARP + SPA CSP
+
+Many ASP.NET Core templates ship with `app.UseHttpsRedirection()` enabled.
+In the `Testing` environment it issues a `307 Temporary Redirect` to the
+absolute HTTPS upstream URL (e.g. `https://localhost:7039/api/...`). When the
+API sits behind a YARP reverse proxy serving an SPA, the browser sees the
+absolute redirect and the SPA's CSP `connect-src 'self'` blocks the follow-up
+request, producing a cryptic `"Failed to fetch"` in every test.
+
+Opt in to HTTP-only mode to short-circuit this:
+
+```csharp
+var app = new FluentUIScaffoldBuilder()
+    .UsePlaywright()
+    .WithHttpOnlyMode()                // <-- inject ASPNETCORE_URLS=http://+:0 + clear ASPNETCORE_HTTPS_PORT
+    .UseAspireHosting<Projects.MyApp_AppHost>(appHost => { }, "web")
+    .Web<WebApp>(options => { })
+    .Build<WebApp>();
+```
+
+This injects two env vars into every Aspire-hosted process:
+
+- `ASPNETCORE_URLS=http://+:0` — Aspire picks the port; no HTTPS endpoint is advertised.
+- `ASPNETCORE_HTTPS_PORT=` (empty) — disables `UseHttpsRedirection`'s port resolution.
+
+Off by default — opt-in only, since it changes wire-protocol expectations.
+
+### Configurable startup timeout + heartbeat
+
+Aspire AppHost startup is bounded to **90 seconds** by default. If startup
+doesn't complete in that window, FluentUIScaffold throws a `TimeoutException`
+naming the timeout duration, instead of hanging indefinitely with no signal.
+
+While startup is in progress, FluentUIScaffold emits an
+`ILogger.LogInformation` line every 10 seconds —
+`"Aspire host starting... ({elapsed}s elapsed)"` — so you can tell whether
+startup is making progress or stuck.
+
+If your AppHost genuinely needs longer (e.g., a heavy database seed):
+
+```csharp
+var app = new FluentUIScaffoldBuilder()
+    .UsePlaywright()
+    .UseAspireHosting<Projects.MyApp_AppHost>(appHost => { }, "web")
+    .WithAspireStartupTimeout(TimeSpan.FromMinutes(3))
+    .Web<WebApp>(options => { })
+    .Build<WebApp>();
+```
+
 ## Documentation
 
 For full documentation, examples, and guides, visit the [GitHub repository](https://github.com/rburnham52/fluent-ui-scaffold).

--- a/tests/FluentUIScaffold.AspireHosting.Tests/AspireStartupTimeoutTests.cs
+++ b/tests/FluentUIScaffold.AspireHosting.Tests/AspireStartupTimeoutTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentUIScaffold.AspireHosting;
+using FluentUIScaffold.Core.Configuration;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FluentUIScaffold.AspireHosting.Tests
+{
+    /// <summary>
+    /// Tests for Aspire startup timeout + heartbeat (Fix 2).
+    /// </summary>
+    [TestClass]
+    public class AspireStartupTimeoutTests
+    {
+        [TestMethod]
+        public async Task StartWithTimeoutAndHeartbeat_FiresTimeoutException_WhenStartupNeverCompletes()
+        {
+            // Simulate Aspire hanging indefinitely by handing back a never-completing task.
+            var hangingTask = new TaskCompletionSource<object?>();
+
+            var ex = await Assert.ThrowsExceptionAsync<TimeoutException>(() =>
+                AspireHostingStrategy<DummyEntryPoint>.StartWithTimeoutAndHeartbeatAsync(
+                    startupFactory: _ => hangingTask.Task,
+                    timeout: TimeSpan.FromMilliseconds(150),
+                    heartbeatInterval: TimeSpan.FromMilliseconds(50),
+                    logger: NullLogger.Instance,
+                    cancellationToken: CancellationToken.None));
+
+            // The message must name the timeout duration so users can act on it
+            // (i.e., know they need to bump WithAspireStartupTimeout).
+            StringAssert.Contains(ex.Message, "0s", "Timeout message should include elapsed-style timing.");
+            StringAssert.Contains(ex.Message, "WithAspireStartupTimeout");
+        }
+
+        [TestMethod]
+        public async Task StartWithTimeoutAndHeartbeat_EmitsHeartbeatLogs_DuringStartup()
+        {
+            var slowTask = Task.Delay(TimeSpan.FromMilliseconds(250));
+            var capturedLogger = new ListLogger();
+
+            await AspireHostingStrategy<DummyEntryPoint>.StartWithTimeoutAndHeartbeatAsync(
+                startupFactory: _ => slowTask,
+                timeout: TimeSpan.FromSeconds(5),
+                heartbeatInterval: TimeSpan.FromMilliseconds(75),
+                logger: capturedLogger,
+                cancellationToken: CancellationToken.None);
+
+            Assert.IsTrue(
+                capturedLogger.Messages.Exists(m => m.Contains("Aspire host starting...")),
+                "Expected at least one 'Aspire host starting...' heartbeat log line during a slow startup. Got:\n"
+                + string.Join("\n", capturedLogger.Messages));
+        }
+
+        [TestMethod]
+        public async Task StartWithTimeoutAndHeartbeat_SucceedsAndStopsHeartbeat_WhenStartupCompletes()
+        {
+            // Should not throw, and should return promptly once the inner task completes.
+            await AspireHostingStrategy<DummyEntryPoint>.StartWithTimeoutAndHeartbeatAsync(
+                startupFactory: _ => Task.CompletedTask,
+                timeout: TimeSpan.FromSeconds(5),
+                heartbeatInterval: TimeSpan.FromSeconds(1),
+                logger: NullLogger.Instance,
+                cancellationToken: CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task StartWithTimeoutAndHeartbeat_PropagatesStartupExceptions()
+        {
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                AspireHostingStrategy<DummyEntryPoint>.StartWithTimeoutAndHeartbeatAsync(
+                    startupFactory: _ => Task.FromException(new InvalidOperationException("boom")),
+                    timeout: TimeSpan.FromSeconds(5),
+                    heartbeatInterval: TimeSpan.FromSeconds(1),
+                    logger: NullLogger.Instance,
+                    cancellationToken: CancellationToken.None));
+
+            Assert.AreEqual("boom", ex.Message);
+        }
+
+        [TestMethod]
+        public void WithAspireStartupTimeout_StoresValueOnBuilderConfig()
+        {
+            var builder = new FluentUIScaffoldBuilder();
+            var returned = builder.WithAspireStartupTimeout(TimeSpan.FromMinutes(2));
+
+            Assert.AreSame(builder, returned);
+            Assert.AreEqual(TimeSpan.FromMinutes(2), AspireHostingExtensions.GetOrCreateConfig(builder).AspireStartupTimeout);
+        }
+
+        [TestMethod]
+        public void WithAspireStartupTimeout_RejectsNonPositiveTimeout()
+        {
+            var builder = new FluentUIScaffoldBuilder();
+            Assert.ThrowsException<ArgumentOutOfRangeException>(
+                () => builder.WithAspireStartupTimeout(TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(
+                () => builder.WithAspireStartupTimeout(TimeSpan.FromSeconds(-1)));
+        }
+
+        /// <summary>Placeholder for the generic type parameter — the timeout helper is static and never touches it.</summary>
+        private sealed class DummyEntryPoint { }
+
+        private sealed class ListLogger : ILogger
+        {
+            public List<string> Messages { get; } = new();
+
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                Messages.Add(formatter(state, exception));
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/tests/FluentUIScaffold.AspireHosting.Tests/DockerPreflightCheckTests.cs
+++ b/tests/FluentUIScaffold.AspireHosting.Tests/DockerPreflightCheckTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+
+using FluentUIScaffold.AspireHosting;
+using FluentUIScaffold.Core.Configuration;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FluentUIScaffold.AspireHosting.Tests
+{
+    /// <summary>
+    /// Tests for the Docker pre-flight health check (Fix 1).
+    /// </summary>
+    [TestClass]
+    public class DockerPreflightCheckTests
+    {
+        [TestMethod]
+        public void DockerUnreachableMessage_IsExposedAsPublicConstant()
+        {
+            // The message text must be exposed publicly so downstream test suites
+            // (e.g., the kitchen-chef BDD suite) can assert on it without hardcoding strings.
+            Assert.IsFalse(string.IsNullOrWhiteSpace(DockerPreflightCheck.DockerUnreachableMessage));
+            StringAssert.Contains(DockerPreflightCheck.DockerUnreachableMessage, "Docker daemon is not reachable");
+            StringAssert.Contains(DockerPreflightCheck.DockerUnreachableMessage, "Resource Saver");
+        }
+
+        [TestMethod]
+        public async Task EnsureDockerHealthyAsync_WithImpossiblyShortTimeout_FailsWithUserMessage()
+        {
+            // 1 millisecond is short enough that the docker CLI cannot possibly start + respond in time,
+            // even on a healthy machine. This proves the unreachable path throws our user-facing message
+            // (and not some inner Docker / process exception).
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => DockerPreflightCheck.EnsureDockerHealthyAsync(timeout: TimeSpan.FromMilliseconds(1)));
+
+            Assert.AreEqual(DockerPreflightCheck.DockerUnreachableMessage, ex.Message);
+
+            // Critical: no inner exception. The whole point of fix 1 is a clean single-line error,
+            // not a stack trace through 20 frames of Aspire's bootstrap.
+            Assert.IsNull(ex.InnerException);
+        }
+
+        [TestMethod]
+        public void SkipDockerPreflightCheck_OptOut_IsHonored()
+        {
+            // Verify the builder extension flips the per-builder config flag.
+            var builder = new FluentUIScaffoldBuilder();
+            var configBefore = AspireHostingExtensions.GetOrCreateConfig(builder);
+            Assert.IsFalse(configBefore.SkipDockerPreflightCheck);
+
+            var returned = builder.SkipDockerPreflightCheck();
+            Assert.AreSame(builder, returned, "Extension should return the builder for chaining.");
+
+            var configAfter = AspireHostingExtensions.GetOrCreateConfig(builder);
+            Assert.IsTrue(configAfter.SkipDockerPreflightCheck);
+        }
+    }
+}

--- a/tests/FluentUIScaffold.AspireHosting.Tests/DockerPreflightCheckTests.cs
+++ b/tests/FluentUIScaffold.AspireHosting.Tests/DockerPreflightCheckTests.cs
@@ -18,7 +18,7 @@ namespace FluentUIScaffold.AspireHosting.Tests
         public void DockerUnreachableMessage_IsExposedAsPublicConstant()
         {
             // The message text must be exposed publicly so downstream test suites
-            // (e.g., the kitchen-chef BDD suite) can assert on it without hardcoding strings.
+            // can assert on it without hardcoding strings.
             Assert.IsFalse(string.IsNullOrWhiteSpace(DockerPreflightCheck.DockerUnreachableMessage));
             StringAssert.Contains(DockerPreflightCheck.DockerUnreachableMessage, "Docker daemon is not reachable");
             StringAssert.Contains(DockerPreflightCheck.DockerUnreachableMessage, "Resource Saver");

--- a/tests/FluentUIScaffold.AspireHosting.Tests/HttpOnlyModeTests.cs
+++ b/tests/FluentUIScaffold.AspireHosting.Tests/HttpOnlyModeTests.cs
@@ -1,0 +1,57 @@
+using FluentUIScaffold.AspireHosting;
+using FluentUIScaffold.Core.Configuration;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FluentUIScaffold.AspireHosting.Tests
+{
+    /// <summary>
+    /// Tests for the HTTP-only mode opt-in (Fix 3).
+    /// </summary>
+    [TestClass]
+    public class HttpOnlyModeTests
+    {
+        [TestMethod]
+        public void WithHttpOnlyMode_Enabled_SetsExpectedEnvironmentVariables()
+        {
+            var builder = new FluentUIScaffoldBuilder();
+
+            builder.WithHttpOnlyMode();
+
+            // Read via Web<T>(opts => ...) to peek at the options
+            FluentUIScaffoldOptions? captured = null;
+            builder.Web<object>(opts => captured = opts);
+            Assert.IsNotNull(captured);
+
+            Assert.IsTrue(captured!.EnvironmentVariables.ContainsKey("ASPNETCORE_URLS"),
+                "HTTP-only mode should inject ASPNETCORE_URLS.");
+            Assert.AreEqual("http://+:0", captured.EnvironmentVariables["ASPNETCORE_URLS"]);
+
+            Assert.IsTrue(captured.EnvironmentVariables.ContainsKey("ASPNETCORE_HTTPS_PORT"),
+                "HTTP-only mode should inject ASPNETCORE_HTTPS_PORT.");
+            Assert.AreEqual(string.Empty, captured.EnvironmentVariables["ASPNETCORE_HTTPS_PORT"]);
+        }
+
+        [TestMethod]
+        public void WithHttpOnlyMode_NotCalled_LeavesEnvironmentVariablesUntouched()
+        {
+            // Default behaviour must stay the same — opt-in only.
+            var builder = new FluentUIScaffoldBuilder();
+
+            FluentUIScaffoldOptions? captured = null;
+            builder.Web<object>(opts => captured = opts);
+
+            Assert.IsNotNull(captured);
+            Assert.IsFalse(captured!.EnvironmentVariables.ContainsKey("ASPNETCORE_URLS"));
+            Assert.IsFalse(captured.EnvironmentVariables.ContainsKey("ASPNETCORE_HTTPS_PORT"));
+        }
+
+        [TestMethod]
+        public void WithHttpOnlyMode_ReturnsBuilderForChaining()
+        {
+            var builder = new FluentUIScaffoldBuilder();
+            var returned = builder.WithHttpOnlyMode();
+            Assert.AreSame(builder, returned);
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

These three fixes are all motivated by a real-world session debugging
the kitchen-chef BDD suite (59 scenarios using `UseAspireHosting<TAppHost>()`).
Each one cost the user (and AI agents) hours that better defaults inside
`FluentUIScaffold.AspireHosting` would have saved.

## Fix 1 — Fail fast when Docker is unhealthy

**Before:** A host crash put Docker Desktop into Resource Saver mode. Every
`dotnet test tests/KitchenChef.BDD.Tests` invocation hung indefinitely at
`AssemblyInitializeAsync`. The real error
(`Container runtime 'docker' was found but appears to be unhealthy. Ensure
that Docker is running...`) was buried ~20 stack frames deep behind
`AspireHostingStrategy → DistributedApplicationFactory → DcpHost →
DcpDependencyCheck.CheckDcpInfoAndLogErrors` and only visible with
`--logger ""console;verbosity=detailed""`.

**After:** `AspireHostingStrategy.StartAsync()` now runs a 2-second
`docker info` probe before booting Aspire. On failure it throws a single
`InvalidOperationException` with a clear user-facing message naming the
common causes (daemon not started, Resource Saver mode, daemon crashed) —
**with no inner exception**, so the cause is not buried in a stack trace.

The exact message is exposed publicly as
`DockerPreflightCheck.DockerUnreachableMessage` so downstream test suites
can assert on it.

Opt out via `.SkipDockerPreflightCheck()` (useful for remote container
runtimes where the local `docker` binary is absent but Aspire still works).

### Before / after error comparison

Before (with `--logger ""console;verbosity=detailed""`, otherwise silent hang):
```
… (20+ stack frames through Aspire internals) …
   at Aspire.Hosting.Dcp.DcpDependencyCheck.CheckDcpInfoAndLogErrors(...)
   at Aspire.Hosting.Dcp.DcpHost.StartAsync(...)
   at Aspire.Hosting.DistributedApplicationFactory.StartAsync(...)
Container runtime 'docker' was found but appears to be unhealthy.
Ensure that Docker is running...
```

After:
```
System.InvalidOperationException: Docker daemon is not reachable.
FluentUIScaffold.AspireHosting requires Docker (or a compatible container
runtime like Rancher Desktop, Podman with Docker compatibility) to be running.

Common causes:
- Docker Desktop / Rancher Desktop is not started
- Docker Desktop is in Resource Saver mode (click the tray icon to wake it)
- The Docker daemon crashed (check the logs)

Start your container runtime and try again.
```

## Fix 2 — Configurable startup timeout + heartbeat

**Before:** Aspire AppHost startup could hang indefinitely with no progress
output. Callers had no way to tell slow startup apart from a stuck one.

**After:** `DistributedApplication.StartAsync` is wrapped in
`Task.WhenAny(startupTask, Task.Delay(timeout))`. Default timeout is
**90 seconds**; on timeout we throw `TimeoutException` naming the duration
and pointing at the override knob:

```csharp
.WithAspireStartupTimeout(TimeSpan.FromMinutes(3))
```

While startup is in progress, an `ILogger.LogInformation` heartbeat fires
every 10 seconds: `""Aspire host starting... ({elapsed}s elapsed)""`.

The core helper is exposed as `internal static
AspireHostingStrategy<TEntryPoint>.StartWithTimeoutAndHeartbeatAsync(...)`
so we can unit-test the timeout/heartbeat behaviour directly against a
`TaskCompletionSource` without spinning up a real Aspire AppHost.

## Fix 3 — HTTP-only mode (opt-in)

**Before:** In `Testing` env, the kitchen-chef API's `UseHttpsRedirection`
returned `307 → https://localhost:7039/api/auth/login`. YARP relayed the
absolute upstream URL to the SPA, the SPA's CSP `connect-src 'self'` blocked
the redirected request, and every BDD sign-in failed with ""Failed to fetch""
— **51 of 59 scenarios red** until manually fixed downstream.

**After:** New `.WithHttpOnlyMode()` builder extension. When enabled, injects
two env vars into every Aspire-hosted process:

- `ASPNETCORE_URLS=http://+:0` — Aspire picks the port; no HTTPS endpoint is advertised.
- `ASPNETCORE_HTTPS_PORT=` (empty) — disables `UseHttpsRedirection`'s port resolution.

Off by default — opt-in only, since it changes wire-protocol expectations.
The XML doc on `WithHttpOnlyMode` explains the YARP+CSP failure mode with
a concrete example so users hit during code completion learn why it exists.

## New public API surface

```csharp
namespace FluentUIScaffold.AspireHosting;

public static class DockerPreflightCheck
{
    public const string DockerUnreachableMessage;
    public static readonly TimeSpan DefaultTimeout;
    public static Task EnsureDockerHealthyAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
}

public sealed class AspireHostingStrategy<TEntryPoint>
{
    public bool SkipDockerPreflightCheck { get; set; }
    public TimeSpan AspireStartupTimeout { get; set; }     // default 90s
    public TimeSpan StartupHeartbeatInterval { get; set; } // default 10s
}

public static class AspireHostingExtensions
{
    public static FluentUIScaffoldBuilder SkipDockerPreflightCheck(this FluentUIScaffoldBuilder builder);
    public static FluentUIScaffoldBuilder WithAspireStartupTimeout(this FluentUIScaffoldBuilder builder, TimeSpan timeout);
    public static FluentUIScaffoldBuilder WithHttpOnlyMode(this FluentUIScaffoldBuilder builder, bool enabled = true);
}
```

## Tests added

- `DockerPreflightCheckTests` (3): message-is-public-constant, impossibly-short-timeout
  throws the user-facing message with no inner exception, builder opt-out flips the flag.
- `AspireStartupTimeoutTests` (6): timeout-on-never-completing-task throws with the
  documented message, heartbeat lines are emitted during slow startup, completed startup
  succeeds and stops the heartbeat, startup exceptions propagate unchanged,
  `WithAspireStartupTimeout` stores the value, non-positive timeouts are rejected.
- `HttpOnlyModeTests` (3): enabled sets both env vars, default behaviour leaves env vars
  untouched, the extension returns the builder for chaining.

Existing `BaseUrlPrefixTests` continue to pass.

## Breaking changes

None. All three fixes are either opt-in (Fix 3) or strictly-better defaults
that surface a clearer error (Fix 1) / replace silent hang with bounded
behaviour (Fix 2). The Docker preflight check can be disabled via
`.SkipDockerPreflightCheck()` for the rare remote-runtime case.

## Test run

`FluentUIScaffold.Core.Tests` (net6.0 + net8.0): 118 + 116 passing, 1 skipped.
`FluentUIScaffold.AspireHosting.Tests` (net8.0): 23 passing (12 new).

`SampleApp.AspireTests` shows 10/10 failures locally on both main and this
branch — Playwright navigation timeouts unrelated to these changes
(reproduced against `main` for the baseline).