### PR TITLE
fix(aspire): reap DCP on failed/timed-out AppHost start

### DIFF
--- a/src/FluentUIScaffold.AspireHosting/AspireHostingStrategy.cs
+++ b/src/FluentUIScaffold.AspireHosting/AspireHostingStrategy.cs
@@ -137,6 +137,26 @@ namespace FluentUIScaffold.AspireHosting
                 logger.LogInformation("Starting distributed application");
                 await StartAppWithTimeoutAndHeartbeatAsync(_app, logger, cancellationToken).ConfigureAwait(false);
             }
+            catch
+            {
+                // A failed or timed-out start can leave a partially-initialized
+                // DistributedApplication with DCP child processes (dcp/dcpproc) and
+                // containers still running. Dispose it here so they are reaped
+                // immediately, instead of relying on a later outer teardown that may
+                // never run (e.g. the test process is force-killed / CI-cancelled).
+                if (_app != null)
+                {
+                    try { await _app.DisposeAsync().ConfigureAwait(false); }
+                    catch (Exception disposeEx)
+                    {
+                        logger.LogWarning(disposeEx,
+                            "Error disposing partially-started Aspire app after a failed start.");
+                    }
+                    _app = null;
+                }
+
+                throw;
+            }
             finally
             {
                 // Restore env vars immediately after CreateAsync + Start.
@@ -328,6 +348,18 @@ namespace FluentUIScaffold.AspireHosting
             // Timeout fired first — try to cancel the in-flight startup so it doesn't
             // continue churning in the background.
             try { startupCts.Cancel(); } catch { /* best-effort */ }
+
+            // Observe the abandoned startup task so that if it later faults (e.g. the
+            // cancelled StartAsync throws), it doesn't surface as an UnobservedTaskException
+            // and tear down the process on GC. We deliberately do NOT await it: a startup
+            // that ignores cancellation could otherwise block us indefinitely — the very
+            // thing this timeout exists to prevent. Reaping the started resources is the
+            // caller's responsibility (it disposes the DistributedApplication on failure).
+            _ = startupTask.ContinueWith(
+                static t => { _ = t.Exception; },
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
 
             throw new TimeoutException(
                 $"Aspire AppHost did not start within {timeout.TotalSeconds:F0}s. " +


### PR DESCRIPTION
## Problem

`AspireHostingStrategy<TEntryPoint>` correctly forwards `DisposeAsync()` to `DistributedApplication.DisposeAsync()` on the **happy path** — but a *failed* or *timed-out* start leaves a partially-initialized `DistributedApplication` undisposed:

- In `StartAsync`, the `try` block does `BuildAsync()` then `StartAppWithTimeoutAndHeartbeatAsync(...)`. There's only a `finally` (restore env vars + release the mutex) — **no `catch`**. So when start throws (notably the `TimeoutException` path), `_app` is assigned but never disposed at the throw site; cleanup is deferred entirely to a later outer teardown.
- `StartWithTimeoutAndHeartbeatAsync` cancels the in-flight start token on timeout and throws, but **abandons** the startup task without observing it.

By that point DCP has usually spawned `dcp.exe`/`dcpproc.exe` (and containers). If the outer teardown is skipped — force-kill, CI cancellation — those orphan. The next run then collides with the leftover DCP session and hangs. This is the classic **"every second test run hangs on stale Aspire processes"** symptom.

## Changes

1. **`StartAsync`** — dispose the partially-started app in a `catch` before rethrowing, so DCP/containers are reaped immediately instead of relying on an outer teardown that may never run.
2. **`StartWithTimeoutAndHeartbeatAsync`** — after cancelling the startup token on timeout, **observe** the abandoned task (non-blocking `ContinueWith`/`OnlyOnFaulted`) so a later fault doesn't surface as an `UnobservedTaskException`. Deliberately **not** awaited: a startup that ignores cancellation would otherwise re-introduce the very hang the timeout exists to prevent.

## What this does / doesn't fix

- ✅ Timeout-aborted **partial starts** now clean up their own DCP session.
- ✅ No more unobserved-exception risk from the abandoned startup task.
- ❌ A **hard kill of the test-runner process itself** can't be covered in-process — for that, pair with a Job Object (`KILL_ON_JOB_CLOSE`) or a post-run DCP reaper in your test harness. (IDEs get this for free via job objects.)

## Tests

All 23 tests in `FluentUIScaffold.AspireHosting.Tests` pass, including the timeout/heartbeat suite. The change to the timeout path is non-blocking, so `StartWithTimeoutAndHeartbeat_FiresTimeoutException_WhenStartupNeverCompletes` (which hands back a never-completing task) still throws promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)